### PR TITLE
fix pageIndex errorSyntax

### DIFF
--- a/PandoranimeService/Services/Scappers/HtmlAgilityPackService.cs
+++ b/PandoranimeService/Services/Scappers/HtmlAgilityPackService.cs
@@ -22,7 +22,7 @@ namespace PandoranimeService.Services.Scappers
 
         public static async Task<List<AnimeByPageModel>> NineAnimeGetListByPageId(int pageIndex)
         {
-            var document = await GetHtmlDoc(NINE_ANIME_LIST_URL+$"?page={2}");
+            var document = await GetHtmlDoc(NINE_ANIME_LIST_URL+$"?page={pageIndex}");
 
             var imagesHtml = document.DocumentNode.SelectNodes("//aside[1]/section[1]/div[2]/ul[1]/li//img");
             var titlesAndUrlsHtml = document.DocumentNode.SelectNodes("//aside[1]/section[1]/div[2]/ul[1]/li//a");


### PR DESCRIPTION
changes NineAnimeGetListByPageId index from 2 to dynamic 